### PR TITLE
fix: fix external scanner

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -5,7 +5,7 @@ void *tree_sitter_gritql_external_scanner_create() {
   return NULL;
 }
 
-bool tree_sitter_xml_external_scanner_scan(void *payload, TSLexer *lexer, const bool *valid_symbols) {
+bool tree_sitter_gritql_external_scanner_scan(void *payload, TSLexer *lexer, const bool *valid_symbols) {
   return false;
 }
 


### PR DESCRIPTION
CI is failing because this function is incorrectly named

```c
bool tree_sitter_xml_external_scanner_scan(void *payload, TSLexer *lexer, const bool *valid_symbols) {
```