### PR TITLE
feat: export wasm file

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
     "build": "tree-sitter generate",
     "parse": "tree-sitter parse",
     "test": "tree-sitter test",
-    "wasm": "tree-sitter build-wasm",
+    "wasm": "tree-sitter build --wasm",
     "web": "tree-sitter web-ui",
-    "generate": "tree-sitter generate && tree-sitter build-wasm",
+    "generate": "tree-sitter generate && tree-sitter build --wasm",
     "install": "node-gyp-build",
     "prebuildify": "prebuildify --napi --strip"
   },


### PR DESCRIPTION
It's a common practice [example](https://github.com/tree-sitter/tree-sitter-javascript/blob/master/package.json#L33) to export the wasm file to its rdeps.

My goal is to integrate `tree-sitter-gritql` parser into the Biome VSCode extension (source: https://github.com/biomejs/biome-vscode/pull/795). The existing node binding doesn't work well on Electron evironment for VSCode extension.

Source: https://github.com/tree-sitter/tree-sitter/tree/master/lib/binding_web#basic-usage

Related issue: https://github.com/honeycombio/tree-sitter-gritql/issues/28. We'll need to publish an npm package with the wasm file in order for the wasm binding to fully work.